### PR TITLE
fix: 修改了一些单词拼写，更新了 EventManagerPlugin 参数的类型定义

### DIFF
--- a/packages/examples/plugins/AxesHelperPlugin.html
+++ b/packages/examples/plugins/AxesHelperPlugin.html
@@ -18,7 +18,7 @@
 
   <body>
     <div id="app"></div>
-    <button id="operate">tirggle</button>
+    <button id="operate">toggle</button>
 
     <script type="module">
       import * as THREE from "three";

--- a/packages/examples/plugins/GridHelperPlugin.html
+++ b/packages/examples/plugins/GridHelperPlugin.html
@@ -18,7 +18,7 @@
 
   <body>
     <div id="app"></div>
-    <button id="operate">tirggle</button>
+    <button id="operate">toggle</button>
 
     <script type="module">
       import * as THREE from "three";

--- a/packages/plugins/EventManagerPlugin/EventManager.ts
+++ b/packages/plugins/EventManagerPlugin/EventManager.ts
@@ -135,15 +135,15 @@ export class EventManager extends EventDispatcher {
 
   /**
    * 使用pointerManger
-   * @param pointerManager 
-   * @returns 
+   * @param pointerManager
+   * @returns
    */
   use(pointerManager: PointerManager): this {
     const mergeEvent = function (event, object) {
       return Object.assign({}, event, object);
     };
 
-    const genericEventHanlder = (event: VisPointerEvent, eventName: string) => {
+    const genericEventHandler = (event: VisPointerEvent, eventName: string) => {
       const intersections = this.intersectObject(event.mouse);
       if (intersections.length) {
         // 穿透事件
@@ -190,7 +190,7 @@ export class EventManager extends EventDispatcher {
 
     for (const name of genericEvents) {
       pointerManager.addEventListener<VisPointerEvent>(name, (event) => {
-        genericEventHanlder(event, name);
+        genericEventHandler(event, name);
       });
     }
 

--- a/packages/plugins/EventManagerPlugin/index.d.ts
+++ b/packages/plugins/EventManagerPlugin/index.d.ts
@@ -6,4 +6,4 @@ export declare const EVENT_MANAGER_PLUGIN: string;
 export interface EventManagerEngine extends PointerManagerEngine {
     eventManager: EventManager;
 }
-export declare const EventManagerPlugin: Plugin<EventManagerEngine, EventManagerParameters>;
+export declare const EventManagerPlugin: Plugin<EventManagerEngine, Partial<EventManagerParameters>>;

--- a/packages/plugins/EventManagerPlugin/index.ts
+++ b/packages/plugins/EventManagerPlugin/index.ts
@@ -21,8 +21,8 @@ export interface EventManagerEngine extends PointerManagerEngine {
 
 export const EventManagerPlugin: Plugin<
   EventManagerEngine,
-  EventManagerParameters
-> = function (params?: EventManagerParameters) {
+  Partial<EventManagerParameters>
+> = function (params?: Partial<EventManagerParameters>) {
   let setCameraFun: ((event: SetCameraEvent) => void) | undefined;
   let setSceneFun: ((event: SetSceneEvent) => void) | undefined;
 

--- a/packages/plugins/loaderManager/index.ts
+++ b/packages/plugins/loaderManager/index.ts
@@ -51,18 +51,18 @@ export const LoaderManagerPlugin: Plugin<
         urlList: Array<LoadUnit>,
         callback: (err: Error | undefined, event?: LoadedEvent) => void
       ) => {
-        const lodedFun = (event: LoadedEvent) => {
+        const loadedFun = (event: LoadedEvent) => {
           callback(undefined, event);
           loaderManager.removeEventListener<LoadedEvent>(
             LOADER_EVENT.LOADED,
-            lodedFun
+            loadedFun
           );
         };
 
         try {
           loaderManager.addEventListener<LoadedEvent>(
             LOADER_EVENT.LOADED,
-            lodedFun
+            loadedFun
           );
         } catch (error) {
           callback(error as Error);
@@ -76,18 +76,18 @@ export const LoaderManagerPlugin: Plugin<
         urlList: Array<LoadUnit>
       ): Promise<LoadedEvent> => {
         return new Promise((resolve, reject) => {
-          const lodedFun = (event: LoadedEvent) => {
+          const loadedFun = (event: LoadedEvent) => {
             resolve(event);
             loaderManager!.removeEventListener<LoadedEvent>(
               LOADER_EVENT.LOADED,
-              lodedFun
+              loadedFun
             );
           };
 
           try {
             loaderManager!.addEventListener<LoadedEvent>(
               LOADER_EVENT.LOADED,
-              lodedFun
+              loadedFun
             );
           } catch (error) {
             reject(error);


### PR DESCRIPTION
1. 修改了部分单词拼写
2.  `@vis-three/plugin-event-manager` 模块，`Plugin<EventManagerEngine, EventManagerParameters>` 改成了 `Plugin<EventManagerEngine, Partial<EventManagerParameters>> `，不然使用的时候必须要传 `scene` 和 `camera`，但是设计上应该是可以不传的。