### PR TITLE
fix(plugin): 卸载 KeyboardMoveControlsPlugins 时清理 engine.keyboardMoveControls

### DIFF
--- a/packages/plugins/KeyboardMoveControlsPlugin/index.d.ts
+++ b/packages/plugins/KeyboardMoveControlsPlugin/index.d.ts
@@ -4,15 +4,24 @@ import { AfterUpdateEvent, BeforeUpdateEvent, KeyboardMoveControls } from "./Key
 export interface KeyboardMoveControlsEngine extends Engine {
     keyboardMoveControls: KeyboardMoveControls;
 }
-export interface FirstPersonControlsParameters {
+export interface KeyboardMoveControlsParameters {
+    /**被控制目标物体 */
     target?: Object3D;
+    /**物体移动速度 */
     movementSpeed?: number;
+    /**物体加速时的速度 */
     quickenSpeed?: number;
+    /**移动方向是基于物体矩阵还是世界矩阵 */
     space?: "local" | "world";
+    /**物体的正前方朝向，可以通过方法获取 */
     forwrad?: Vector3 | ((object: Object3D) => Vector3);
+    /**扩展的键盘按下时的方法 */
     extendKeyDown?: (event: KeyboardEvent) => void;
+    /**扩展的键盘抬起的方法 */
     extendKeyUp?: (event: KeyboardEvent) => void;
+    /**在物体位置更新前的扩展处理方法 */
     beforeUpdate?: (event: BeforeUpdateEvent) => void;
+    /**在物体位置更新后的扩展处理方法 */
     afterUpdate?: (event: AfterUpdateEvent) => void;
 }
 export declare const KEYBOARD_MOVE_CONTROLS_PLUGIN: string;

--- a/packages/plugins/KeyboardMoveControlsPlugin/index.js
+++ b/packages/plugins/KeyboardMoveControlsPlugin/index.js
@@ -1,4 +1,4 @@
-import { ENGINE_EVENT, } from "@vis-three/core";
+import { ENGINE_EVENT } from "@vis-three/core";
 import { transPkgName } from "@vis-three/utils";
 import { KeyboardMoveControls, } from "./KeyboardMoveControls";
 import { name as pkgname } from "./package.json";
@@ -47,6 +47,8 @@ export const KeyboardMoveControlsPlugin = function (params = {}) {
             engine.removeEventListener(ENGINE_EVENT.SETDOM, setDomFun);
             engine.removeEventListener(ENGINE_EVENT.SETCAMERA, setCameraFun);
             engine.removeEventListener(ENGINE_EVENT.RENDER, renderFun);
+            engine.keyboardMoveControls?.dispose();
+            delete engine.keyboardMoveControls;
         },
     };
 };

--- a/packages/plugins/KeyboardMoveControlsPlugin/index.ts
+++ b/packages/plugins/KeyboardMoveControlsPlugin/index.ts
@@ -4,8 +4,7 @@ import {
   Plugin,
   RenderEvent,
   SetCameraEvent,
-  SetDomEvent,
-  SetSizeEvent,
+  SetDomEvent
 } from "@vis-three/core";
 import { Optional, transPkgName } from "@vis-three/utils";
 import { Object3D, Vector3 } from "three";
@@ -124,6 +123,9 @@ export const KeyboardMoveControlsPlugin: Plugin<KeyboardMoveControlsEngine> =
         );
 
         engine.removeEventListener<RenderEvent>(ENGINE_EVENT.RENDER, renderFun);
+
+        engine.keyboardMoveControls?.dispose()
+        delete engine.keyboardMoveControls;
       },
     };
   };


### PR DESCRIPTION
确保在插件卸载时正确释放 KeyboardMoveControls 实例，避免潜在问题